### PR TITLE
Tweak handling of configuration files

### DIFF
--- a/src/main/java/io/bastillion/common/db/DBInitServlet.java
+++ b/src/main/java/io/bastillion/common/db/DBInitServlet.java
@@ -89,7 +89,7 @@ public class DBInitServlet extends javax.servlet.http.HttpServlet {
                     AppConfig.encryptProperty("dbPassword", RandomStringUtils.random(32, true, true));
                 }
                 //else encrypt password if plain-text
-            } else if (!AppConfig.isPropertyEncrypted("dbPassword")) {
+            } else if (!AppConfig.isPropertyEncrypted("dbPassword") && AppConfig.isWritableOrInsecure()) {
                 AppConfig.encryptProperty("dbPassword", AppConfig.getProperty("dbPassword"));
             }
 

--- a/src/main/java/io/bastillion/common/util/AppConfig.java
+++ b/src/main/java/io/bastillion/common/util/AppConfig.java
@@ -15,6 +15,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.Set;
@@ -182,5 +186,22 @@ public class AppConfig {
         }
     }
 
+    /**
+     * check if the config file is writable.
+     *
+     * if the configuration file is world readable, we still try to update it so the user has an error and deals with it
+     */
+    public static boolean isWritableOrInsecure() {
+        Path path = prop.getFile().toPath();
+        try {
+            return Files.isWritable(path)
+                || Files.getPosixFilePermissions(path).contains(PosixFilePermission.OTHERS_READ);
+        } catch (UnsupportedOperationException e) {
+            // if the filesystem doesn't support checking permissions, assume it's writable
+            return true;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
 }

--- a/src/main/java/io/bastillion/common/util/AppConfig.java
+++ b/src/main/java/io/bastillion/common/util/AppConfig.java
@@ -32,18 +32,18 @@ public class AppConfig {
         try {
             //move configuration to specified dir
             if (StringUtils.isNotEmpty(System.getProperty("CONFIG_DIR"))) {
-                File configFile = new File(CONFIG_DIR + "BastillionConfig.properties");
+                File configFile = new File(CONFIG_DIR + "/BastillionConfig.properties");
                 if (!configFile.exists()) {
                     File oldConfig = new File(AppConfig.class.getClassLoader().getResource(".").getPath() + "BastillionConfig.properties");
                     FileUtils.moveFile(oldConfig, configFile);
                 }
-                configFile = new File(CONFIG_DIR + "jaas.conf");
+                configFile = new File(CONFIG_DIR + "/jaas.conf");
                 if (!configFile.exists()) {
                     File oldConfig = new File(AppConfig.class.getClassLoader().getResource(".").getPath() + "jaas.conf");
                     FileUtils.moveFile(oldConfig, configFile);
                 }
             }
-            prop = new PropertiesConfiguration(CONFIG_DIR + "BastillionConfig.properties");
+            prop = new PropertiesConfiguration(CONFIG_DIR + "/BastillionConfig.properties");
         } catch (IOException | ConfigurationException ex) {
             log.error(ex.toString(), ex);
         }


### PR DESCRIPTION
* Systematically add a / behind `CONFIG_DIR`. Previously, sometimes a / was added, sometimes not. Since it's common to write path without trailing slash, ensure it works in those cases.
* Don't try and modify the configuration file if it's already secure. We already setup our configuration so that only bastillion can read it and bastillion absolutely cannot modify its own configuration.

Let me know if you think these changes are appropriate.